### PR TITLE
Change `MODULE_IMPORT_NS()` parameter to string literal for kernels >…

### DIFF
--- a/src/gasket_page_table.c
+++ b/src/gasket_page_table.c
@@ -54,7 +54,11 @@
 #include <linux/vmalloc.h>
 
 #if __has_include(<linux/dma-buf.h>)
-MODULE_IMPORT_NS(DMA_BUF);
+	#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 13, 0)
+	MODULE_IMPORT_NS(DMA_BUF);
+	#else
+	MODULE_IMPORT_NS("DMA_BUF");
+	#endif
 #endif
 
 #include "gasket_constants.h"


### PR DESCRIPTION
…= 6.13

In kernel 6.13 the `MODULE_IMPORT_NS()` function has been changed to accept string literals instead of macro expansions.

See https://github.com/torvalds/linux/commit/cdd30ebb1b9f36159d66f088b61aee264e649d7a